### PR TITLE
Use SecretsManager for RDS credentials

### DIFF
--- a/developer_defaults.tf
+++ b/developer_defaults.tf
@@ -57,7 +57,7 @@ variable "survey_runner_min_tasks" {
 
 variable "respondent_account_url" {
   description = "The url for the respondent log in"
-  default     = "https://survey.ons.gov.uk/"
+  default     = "https://surveys.ons.gov.uk/"
 }
 
 variable "survey_runner_log_level" {


### PR DESCRIPTION
This PR removes the `DB_CONNECTION_URI` environment variable in favour of the `DB_SECRET_ID` environment variable.

This allows the app to load the database secrets on startup so the api does not need to be passed any secrets.

Running this PR also tests https://github.com/ONSdigital/eq-terraform/pull/155