### PR TITLE
Expose the API status page

### DIFF
--- a/author.tf
+++ b/author.tf
@@ -300,7 +300,7 @@ module "author-api" {
   ecs_subnet_ids             = "${module.author-eq-ecs.ecs_subnet_ids}"
   ecs_alb_security_group     = ["${module.author-eq-ecs.ecs_alb_security_group}"]
   launch_type                = "FARGATE"
-  alb_listener_path_patterns = ["/graphql*", "/launch*"]
+  alb_listener_path_patterns = ["/graphql*", "/launch*", "/status"]
   auth_unauth_action         = "deny"
 
   container_environment_variables = <<EOF


### PR DESCRIPTION
Concourse is failing because it can't check the version of the API from the status page