### PR TITLE
Use DynamoDB in on-demand mode

### DIFF
--- a/author.tf
+++ b/author.tf
@@ -225,6 +225,8 @@ module "author-survey-runner-static" {
   ecs_subnet_ids             = "${module.author-eq-ecs.ecs_subnet_ids}"
   ecs_alb_security_group     = ["${module.author-eq-ecs.ecs_alb_security_group}"]
   launch_type                = "FARGATE"
+  cpu_units                  = "256"
+  memory_units               = "512"
 }
 
 module "author" {
@@ -251,6 +253,8 @@ module "author" {
   ecs_subnet_ids                   = "${module.author-eq-ecs.ecs_subnet_ids}"
   ecs_alb_security_group           = ["${module.author-eq-ecs.ecs_alb_security_group}"]
   launch_type                      = "FARGATE"
+  cpu_units                        = "256"
+  memory_units                     = "512"
   auth_unauth_action               = "authenticate"
 
   container_environment_variables = <<EOF
@@ -376,6 +380,8 @@ module "author-schema-validator" {
   ecs_subnet_ids         = "${module.author-eq-ecs.ecs_subnet_ids}"
   ecs_alb_security_group = ["${module.author-eq-ecs.ecs_alb_security_group}"]
   launch_type            = "FARGATE"
+  cpu_units              = "256"
+  memory_units           = "512"
 }
 
 module "author-database" {
@@ -401,19 +407,11 @@ module "author-database" {
 }
 
 module "author-survey-runner-dynamodb" {
-  source                                 = "github.com/ONSdigital/eq-terraform-dynamodb?ref=v2.0"
+  source                                 = "github.com/ONSdigital/eq-terraform-dynamodb?ref=v2.2"
   env                                    = "${var.env}-author"
   aws_account_id                         = "${var.aws_account_id}"
   aws_assume_role_arn                    = "${var.aws_assume_role_arn}"
   slack_alert_sns_arn                    = "${module.eq-alerting.slack_alert_sns_arn}"
-  submitted_responses_min_read_capacity  = 1
-  submitted_responses_min_write_capacity = 1
-  questionnaire_state_min_read_capacity  = 5
-  questionnaire_state_min_write_capacity = 5
-  eq_session_min_read_capacity           = 5
-  eq_session_min_write_capacity          = 5
-  used_jti_claim_min_read_capacity       = 1
-  used_jti_claim_min_write_capacity      = 1
 }
 
 output "author_service_address" {


### PR DESCRIPTION
This sets the Runner dynamodb tables to on-demand mode

Tests ONSdigital/eq-terraform-dynamodb#14

Also, reduces the size of some of the containers that don't do a lot