### PR TITLE
Add Google Tag Manager variables

### DIFF
--- a/author.tf
+++ b/author.tf
@@ -279,6 +279,14 @@ module "author" {
       {
         "name": "REACT_APP_FIREBASE_API_KEY",
         "value": "${var.author_firebase_api_key}"
+      },
+      {
+        "name": "REACT_APP_GTM_ID",
+        "value": "${var.author_gtm_id}"
+      },
+      {
+        "name": "REACT_APP_GTM_ENV_ID",
+        "value": "${var.author_gtm_env_id}"
       }
   EOF
 }

--- a/developer_defaults.tf
+++ b/developer_defaults.tf
@@ -153,6 +153,16 @@ variable "author_firebase_api_key" {
   description = "The Firebase authentication API key"
 }
 
+variable "author_gtm_id" {
+  description = "The Google Tag Manager container ID"
+  default     = ""
+}
+
+variable "author_gtm_env_id" {
+  description = "The Google Tag Manager environment ID"
+  default     = ""
+}
+
 variable "author_min_tasks" {
   description = "The minimum number of Author tasks to run"
   default     = "1"


### PR DESCRIPTION
This PR is to add the environment variables for Google Tag Manager. The container ID will link Author to the GTM author container and the environment ID will link Author to the correct environment within that container.