### PR TITLE
Allow for enabling/disabling import endpoint

### DIFF
--- a/author.tf
+++ b/author.tf
@@ -337,6 +337,10 @@ module "author-api" {
       {
         "name": "DYNAMO_QUESTIONNAIRE_VERSION_TABLE_NAME",
         "value": "${module.author-dynamodb.author_questionnaire_versions_table_name}"
+      },
+      {
+        "name": "ENABLE_IMPORT",
+        "value": "${var.author_api_enable_import}"
       }
   EOF
 

--- a/developer_defaults.tf
+++ b/developer_defaults.tf
@@ -163,6 +163,11 @@ variable "author_gtm_env_id" {
   default     = ""
 }
 
+variable "author_api_enable_import" {
+  description = "Whether to enable the import endpoint on the api"
+  default     = "false"
+}
+
 variable "author_min_tasks" {
   description = "The minimum number of Author tasks to run"
   default     = "1"


### PR DESCRIPTION
Add variable to allow for enabling import to be specified

You should set `author_api_enable_import="true"` in your `terraform.tfvars`

Dependencies:
- [x] - https://github.com/ONSdigital/eq-author-app/pull/330