### PR TITLE
Added config for new users table

### DIFF
--- a/author.tf
+++ b/author.tf
@@ -341,6 +341,9 @@ module "author-api" {
       {
         "name": "ENABLE_IMPORT",
         "value": "${var.author_api_enable_import}"
+      },
+        "name": "DYNAMO_USER_TABLE_NAME",
+        "value": "${module.author-dynamodb.author_users_table_name}"
       }
   EOF
 
@@ -373,6 +376,18 @@ module "author-api" {
               "dynamodb:Query"
           ],
           "Resource": "${module.author-dynamodb.author_questionnaire_versions_table_arn}"
+      },
+      {
+          "Sid": "",
+          "Effect": "Allow",
+          "Action": [
+              "dynamodb:Scan",
+              "dynamodb:DescribeTable",
+              "dynamodb:PutItem",
+              "dynamodb:UpdateItem",
+              "dynamodb:GetItem"
+          ],
+          "Resource": "${module.author-dynamodb.author_users_table_arn}"
       }
   ]
 }


### PR DESCRIPTION
This Pr adds the config required to create a new users table in the dynamo db.

Review by checking out this branch and change the source of the author-dynamodb module to `github.com/ONSdigital/eq-author-terraform-dynamodb?ref=976-map-our-user-type-to-a-table` and attempting to spin up a personal instance, if all works as expected everything should work as before just with the addition of a new db table.

### Dependant on : https://github.com/ONSdigital/eq-author-terraform-dynamodb/pull/2