### PR TITLE
Add import and export paths to the ALB listener rules

### DIFF
--- a/author.tf
+++ b/author.tf
@@ -314,7 +314,7 @@ module "author-api" {
   ecs_subnet_ids             = "${module.author-eq-ecs.ecs_subnet_ids}"
   ecs_alb_security_group     = ["${module.author-eq-ecs.ecs_alb_security_group}"]
   launch_type                = "FARGATE"
-  alb_listener_path_patterns = ["/graphql*", "/launch*", "/status"]
+  alb_listener_path_patterns = ["/graphql*", "/launch*", "/status", "/export*", "/import*"]
   auth_unauth_action         = "deny"
 
   container_environment_variables = <<EOF


### PR DESCRIPTION
In PR #9 it didn't actually expose it for it to be used.