### PR TITLE
Add ability to read secrets from S3 bucket.

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,18 @@ slack_webhook_path=""
 # Create your own credentials here https://firebase.google.com/
 author_firebase_project_id=""
 author_firebase_api_key=""
+
+# A service account is required to verify Firebase tokens in Author's API.
+# A key file can be generated for the service account by following the instructions at https://firebase.google.com/docs/admin/setup#initialize_the_sdk
+# The following variable needs to be set and should be a path to the JSON key file.
+author_firebase_service_account_key=""
+
+#The key file can be synced from an S3 bucket by setting the following variable
+author_secrets_bucket_name=""
+
+# See also https://github.com/ONSdigital/eq-author-app/blob/master/docs/AUTHENTICATION.md
+
+
 ```
 
 1. Run `aws configure`. Add your AWS access key and secret key when prompted for S3. Use "eu-west-1" as your region name. Leave any other values as default.

--- a/README.md
+++ b/README.md
@@ -36,12 +36,13 @@ author_firebase_api_key=""
 # A service account is required to verify Firebase tokens in Author's API.
 # A key file can be generated for the service account by following the instructions at https://firebase.google.com/docs/admin/setup#initialize_the_sdk
 # The following variable needs to be set to the absolute path of the JSON key file within the container.
-# If syncing from S3 (see below) this will be something like '/secrets/path-to-key-file.json'
+# Assuming the key is synced from an S3 bucket (see below), this will be something like '/secrets/path-to-key-file.json'
 author_firebase_service_account_key=""
 
 # The key file can be synced from an S3 bucket by setting the following variable.
 # If set, the contents of this bucket will be synced to the /secrets directory within the container.
-author_secrets_bucket_name=""
+
+# author_secrets_bucket_name=""
 
 # See also https://github.com/ONSdigital/eq-author-app/blob/master/docs/AUTHENTICATION.md
 

--- a/README.md
+++ b/README.md
@@ -35,10 +35,12 @@ author_firebase_api_key=""
 
 # A service account is required to verify Firebase tokens in Author's API.
 # A key file can be generated for the service account by following the instructions at https://firebase.google.com/docs/admin/setup#initialize_the_sdk
-# The following variable needs to be set and should be a path to the JSON key file.
+# The following variable needs to be set to the absolute path of the JSON key file within the container.
+# If syncing from S3 (see below) this will be something like '/secrets/path-to-key-file.json'
 author_firebase_service_account_key=""
 
-#The key file can be synced from an S3 bucket by setting the following variable
+# The key file can be synced from an S3 bucket by setting the following variable.
+# If set, the contents of this bucket will be synced to the /secrets directory within the container.
 author_secrets_bucket_name=""
 
 # See also https://github.com/ONSdigital/eq-author-app/blob/master/docs/AUTHENTICATION.md

--- a/author.tf
+++ b/author.tf
@@ -377,7 +377,7 @@ module "author-api" {
               "s3:ListBucket",
               "s3:GetObject"
           ],
-          "Resource": "arn:aws:s3:::*"
+          "Resource": "arn:aws:s3:::${var.author_secrets_bucket_name}"
       },
       {
           "Sid": "",

--- a/author.tf
+++ b/author.tf
@@ -373,6 +373,16 @@ module "author-api" {
           "Sid": "",
           "Effect": "Allow",
           "Action": [
+              "s3:ListObjects",
+              "s3:ListBucket",
+              "s3:GetObject"
+          ],
+          "Resource": "arn:aws:s3:::*"
+      },
+      {
+          "Sid": "",
+          "Effect": "Allow",
+          "Action": [
               "dynamodb:Scan",
               "dynamodb:DescribeTable",
               "dynamodb:PutItem",

--- a/author.tf
+++ b/author.tf
@@ -359,7 +359,7 @@ module "author-api" {
       {
         "name": "GOOGLE_APPLICATION_CREDENTIALS",
         "value": "${var.author_firebase_service_account_key}"
-      },
+      }
 
   EOF
 

--- a/author.tf
+++ b/author.tf
@@ -351,7 +351,16 @@ module "author-api" {
       {
         "name": "DYNAMO_USER_TABLE_NAME",
         "value": "${module.author-dynamodb.author_users_table_name}"
-      }
+      },
+      {
+        "name": "SECRETS_S3_BUCKET",
+        "value": "${var.author_secrets_bucket_name}"
+      },
+      {
+        "name": "GOOGLE_APPLICATION_CREDENTIALS",
+        "value": "${var.author_firebase_service_account_key}"
+      },
+
   EOF
 
   task_has_iam_policy = true

--- a/developer_defaults.tf
+++ b/developer_defaults.tf
@@ -153,6 +153,14 @@ variable "author_firebase_api_key" {
   description = "The Firebase authentication API key"
 }
 
+variable "author_firebase_service_account_key" {
+  description = "A path to the service account JSON key file"
+}
+
+variable "author_secrets_bucket_name" {
+  description = "Name of S3 bucket where Author secrets are stored"
+}
+
 variable "author_gtm_id" {
   description = "The Google Tag Manager container ID"
   default     = ""

--- a/terraform.tfvars.example
+++ b/terraform.tfvars.example
@@ -8,4 +8,13 @@ slack_webhook_path=""
 
 author_firebase_project_id=""
 author_firebase_api_key=""
+
+# A service account is required to verify Firebase tokens in Author's API.
+# A key file can be generated for the service account by following the instructions at https://firebase.google.com/docs/admin/setup#initialize_the_sdk
+# The following variable needs to be set and should be a path to the JSON key file.
 author_firebase_service_account_key=""
+
+# The key file can be synced from an S3 bucket by setting the following variable
+# author_secrets_bucket_name=""
+
+# See also https://github.com/ONSdigital/eq-author-app/blob/master/docs/AUTHENTICATION.md

--- a/terraform.tfvars.example
+++ b/terraform.tfvars.example
@@ -11,10 +11,13 @@ author_firebase_api_key=""
 
 # A service account is required to verify Firebase tokens in Author's API.
 # A key file can be generated for the service account by following the instructions at https://firebase.google.com/docs/admin/setup#initialize_the_sdk
-# The following variable needs to be set and should be a path to the JSON key file.
+# The following variable needs to be set to the absolute path of the JSON key file within the container.
+# If syncing from S3 (see below) this will be something like '/secrets/path-to-key-file.json'
 author_firebase_service_account_key=""
 
-# The key file can be synced from an S3 bucket by setting the following variable
+# The key file can be synced from an S3 bucket by setting the following variable.
+# If set, the contents of this bucket will be synced to the /secrets directory within the container.
+
 # author_secrets_bucket_name=""
 
 # See also https://github.com/ONSdigital/eq-author-app/blob/master/docs/AUTHENTICATION.md

--- a/terraform.tfvars.example
+++ b/terraform.tfvars.example
@@ -12,7 +12,7 @@ author_firebase_api_key=""
 # A service account is required to verify Firebase tokens in Author's API.
 # A key file can be generated for the service account by following the instructions at https://firebase.google.com/docs/admin/setup#initialize_the_sdk
 # The following variable needs to be set to the absolute path of the JSON key file within the container.
-# If syncing from S3 (see below) this will be something like '/secrets/path-to-key-file.json'
+# Assuming the key is synced from an S3 bucket (see below), this will be something like '/secrets/path-to-key-file.json'
 author_firebase_service_account_key=""
 
 # The key file can be synced from an S3 bucket by setting the following variable.

--- a/terraform.tfvars.example
+++ b/terraform.tfvars.example
@@ -8,3 +8,4 @@ slack_webhook_path=""
 
 author_firebase_project_id=""
 author_firebase_api_key=""
+author_firebase_service_account_key=""


### PR DESCRIPTION
### What is the context of this PR?
Author API needs the ability to be able to read a Firebase service account key, which is unique for each environment).

This change introduces a couple of new variables to the Author terraform configuration to allow the API to sync and load its secret keys from an S3 bucket.

### How to test
- Create a firebase project and generate a new service account key for the project.
- Place the JSON key file in an S3 bucket in the dev account.
- Set the new variables appropriately.
- Ensure that `author_tag` variable is pointing at this branch: https://github.com/ONSdigital/eq-author-app/pull/369.
- Run terraform and ensure that API loads key from the S3 bucket (look at Cloudwatch logs on container start up).
- Remember to run `terraform destroy` after you're finished.