### PR TITLE
Remove host header from author-api listener rules.

### DIFF
--- a/author.tf
+++ b/author.tf
@@ -241,8 +241,9 @@ module "author" {
   vpc_id                           = "${module.author-vpc.vpc_id}"
   aws_alb_arn                      = "${module.author-eq-ecs.aws_external_alb_arn}"
   aws_alb_listener_arn             = "${module.author-eq-ecs.aws_external_alb_listener_arn}"
+  aws_alb_use_host_header          = false
   service_name                     = "author"
-  listener_rule_priority           = 400
+  listener_rule_priority           = 900
   docker_registry                  = "${var.author_registry}"
   container_name                   = "eq-author"
   container_port                   = 3000
@@ -306,6 +307,7 @@ module "author-api" {
   vpc_id                     = "${module.author-vpc.vpc_id}"
   aws_alb_arn                = "${module.author-eq-ecs.aws_external_alb_arn}"
   aws_alb_listener_arn       = "${module.author-eq-ecs.aws_external_alb_listener_arn}"
+  aws_alb_use_host_header    = false
   service_name               = "author-api"
   listener_rule_priority     = 300
   docker_registry            = "${var.author_registry}"
@@ -501,4 +503,20 @@ module "author-dynamodb" {
 
 output "author_service_address" {
   value = "${module.author.service_address}"
+}
+
+resource "aws_lb_listener" "redirect_http_to_https" {
+  load_balancer_arn = "${module.author-eq-ecs.aws_external_alb_arn}"
+  port              = "80"
+  protocol          = "HTTP"
+
+  default_action {
+    type = "redirect"
+
+    redirect {
+      port        = "443"
+      protocol    = "HTTPS"
+      status_code = "HTTP_301"
+    }
+  }
 }


### PR DESCRIPTION
## What is the context of this PR?
Since the introduction of the author short url was done manually, outside of terraform, there were conflicting listener rule priority values upon the next deployment to prod.

This PR removes the host from the listener rules for the API so that traffic should be routed to the API both when the short url is used and also when the prod dns name is used.

**Edit: I have modified this PR to also (optionally) create a listener rule for the author short URL and redirect traffic from HTTP 80 to HTTPS 443.**

## How to test
Deploy into a dev environment and ensure that app behaves correctly.
Observe in the listener rules for the load balancer that the host header is not present when routing traffic to the API.