### PR TITLE
Add firebase project Id env variable to Author-API.

### DIFF
--- a/author.tf
+++ b/author.tf
@@ -351,6 +351,10 @@ module "author-api" {
       {
         "name": "DYNAMO_USER_TABLE_NAME",
         "value": "${module.author-dynamodb.author_users_table_name}"
+      },
+      {
+        "name": "FIREBASE_PROJECT_ID",
+        "value": "${var.author_firebase_project_id}"
       }
   EOF
 


### PR DESCRIPTION
### What is the context of this change?
In order to verify Firebase tokens on the API (see https://github.com/ONSdigital/eq-author-app/pull/427) the API needs knowledge of the Firebase project Id so that it can check that the token was issued by the correct project.

This PR passes an additional variable to the author API container, which is used when the eq-author-terraform script is run (when provisioning staging environment).