### PR TITLE
Add new environment variable for GTM preview Id.

### DIFF
--- a/author.tf
+++ b/author.tf
@@ -286,8 +286,12 @@ module "author" {
         "value": "${var.author_gtm_id}"
       },
       {
-        "name": "REACT_APP_GTM_ENV_ID",
-        "value": "${var.author_gtm_env_id}"
+        "name": "REACT_APP_GTM_AUTH",
+        "value": "${var.author_gtm_auth}"
+      },
+      {
+        "name": "REACT_APP_GTM_PREVIEW",
+        "value": "${var.author_gtm_preview}"
       },
       {
         "name": "REACT_APP_SENTRY_DSN",

--- a/developer_defaults.tf
+++ b/developer_defaults.tf
@@ -158,8 +158,13 @@ variable "author_gtm_id" {
   default     = ""
 }
 
-variable "author_gtm_env_id" {
+variable "author_gtm_auth" {
   description = "The Google Tag Manager environment ID"
+  default     = ""
+}
+
+variable "author_gtm_preview" {
+  description = "The Google Tag Manager preview environment"
   default     = ""
 }
 


### PR DESCRIPTION
### What is the context of this PR?
Previously the preview Id was being hard coded in Author. This change introduces a new environment variable to pass in the preview Id and renames the GTM `env id` to `auth` so that it is consistent with documentation in the GTM library used on Author.

### How to test
1. Checkout this branch
1. Configure the GTM terraform variables in developer defaults (values can be obtained from Staging for test purposes).
1. Run terraform to deploy the environment.
1. Once completed, inspect the docker container in AWS to ensure the environment variables are being set correctly.
1. Navigate to the author link for the deployed environment and view source to ensure that the GTM `script` and `noscript` tags are being set correctly.
1. Don't forget to run `terraform destroy` once you are finished.