### PR TITLE
Add variable for survey register tag

### DIFF
--- a/author.tf
+++ b/author.tf
@@ -514,12 +514,12 @@ module "survey-register" {
   vpc_id                 = "${module.author-vpc.vpc_id}"
   aws_alb_arn            = "${module.author-eq-ecs.aws_external_alb_arn}"
   aws_alb_listener_arn   = "${module.author-eq-ecs.aws_external_alb_listener_arn}"
-  service_name           = "survey-register"
+  service_name           = "author-survey-register"
   listener_rule_priority = 600
   docker_registry        = "${var.author_registry}"
   container_name         = "eq-survey-register"
   container_port         = 8080
-  container_tag          = "${var.author_tag}"
+  container_tag          = "${var.register_tag}"
   healthcheck_path       = "/status"
   application_min_tasks  = "${var.survey_register_min_tasks}"
   slack_alert_sns_arn    = "${module.eq-alerting.slack_alert_sns_arn}"

--- a/developer_defaults.tf
+++ b/developer_defaults.tf
@@ -208,6 +208,11 @@ variable "survey_launcher_jwt_signing_key_path" {
   default     = "jwt-test-keys/sdc-user-authentication-signing-launcher-private-key.pem"
 }
 
+variable "register_tag" {
+  description = "The tag for the Survey Register image to run"
+  default     = "latest"
+}
+
 variable "survey_register_min_tasks" {
   description = "The minimum number of Survey Register tasks to run"
   default     = "1"


### PR DESCRIPTION
The old config was working when tested individually how it failed in concourse due to different tags being used, the PR ensues that the correct vars will be pulled in. 