### PR TITLE
Added permissions to terrafrom to query questionnaire table

### DIFF
--- a/author.tf
+++ b/author.tf
@@ -436,7 +436,8 @@ module "author-api" {
               "dynamodb:PutItem",
               "dynamodb:UpdateItem",
               "dynamodb:GetItem",
-              "dynamodb:DeleteItem"
+              "dynamodb:DeleteItem",
+              "dynamodb:Query"
           ],
           "Resource": "${module.author-dynamodb.author_questionnaires_table_arn}"
       },


### PR DESCRIPTION
The terraform script just needed to be updated to allow us to query the questionnaire table instead of just scanning it.