### PR TITLE
added comment config

### DIFF
--- a/author.tf
+++ b/author.tf
@@ -400,6 +400,10 @@ module "author-api" {
         "value": "${module.author-dynamodb.author_questionnaire_versions_table_name}"
       },
       {
+        "name": "DYNAMO_COMMENTS_TABLE_NAME",
+        "value": "${module.author-dynamodb.author_comments_table_name}"
+      },
+      {
         "name": "ENABLE_IMPORT",
         "value": "${var.author_api_enable_import}"
       },
@@ -464,6 +468,20 @@ module "author-api" {
               "dynamodb:Query"
           ],
           "Resource": "${module.author-dynamodb.author_users_table_arn}"
+      },
+      {
+          "Sid": "",
+          "Effect": "Allow",
+          "Action": [
+              "dynamodb:Scan",
+              "dynamodb:DescribeTable",
+              "dynamodb:PutItem",
+              "dynamodb:UpdateItem",
+              "dynamodb:GetItem",
+              "dynamodb:DeleteItem",
+              "dynamodb:Query"
+          ],
+          "Resource": "${module.author-dynamodb.author_comments_table_arn}"
       }
   ]
 }
@@ -628,7 +646,7 @@ module "author-survey-runner-dynamodb" {
 }
 
 module "author-dynamodb" {
-  source              = "github.com/ONSdigital/eq-author-terraform-dynamodb?ref=v0.3"
+  source              = "github.com/ONSdigital/eq-author-terraform-dynamodb?ref=v0.4"
   env                 = "${var.env}-author"
   aws_account_id      = "${var.aws_account_id}"
   aws_assume_role_arn = "${var.aws_assume_role_arn}"


### PR DESCRIPTION
To test this PR we need to ensure the changes in the comments table are included in the staging environment:

First branch this repo with "Your-Repo-name"

A) Go to file - author.tf
line 649
source = "github.com/ONSdigital/eq-author-terraform-dynamodb?ref=v0.4"
change :   ref=v0.4 to ref="Your-Repo-name"

B) Go to file - developer_defaults
line 145
default  = "latest"
change to:   default  = "Your-Repo-name"

C) Spin up your local Staging environment (See Steps  E onwards if unsure how)

D) Test that you are able to create and view new comments on both Question pages and Calculated Summary Page

E) In your local eq-author-terraform directory 
(Clone https://github.com/ONSdigital/eq-author-terraform if you havn't already)
$ - terraform init 
(if never run before)

F) $ - terraform plan 
(if never run before)

G) $ - caffienate -i terraform apply
( will take approx 10mins - MAKE SURE MACHINE DOES NOT GO TO SLEEP - or you will spend hours fixing it!!!)
Browse to the URL generated  and return to step D above

